### PR TITLE
Talk on org.kde.StatusNotifierWatcher

### DIFF
--- a/com.github.eneshecan.WhatsAppForLinux.yml
+++ b/com.github.eneshecan.WhatsAppForLinux.yml
@@ -12,6 +12,7 @@ finish-args:
   - --socket=pulseaudio
   - --share=network
   - --talk-name=org.freedesktop.Notifications
+  - --talk-name=org.kde.StatusNotifierWatcher
   - --filesystem=xdg-desktop
   - --filesystem=xdg-documents
   - --filesystem=xdg-download


### PR DESCRIPTION
This is necessary for the SNI icon to be shown, otherwise the fallback X11 tray icon is used instead.