### PR TITLE
Delist application due to trademark violation

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,3 @@
+{
+  "end-of-life": "This application has been delisted."
+}


### PR DESCRIPTION
Nothing was fixed after the stipulated 2 months, see https://github.com/flathub/com.github.eneshecan.WhatsAppForLinux/issues/14

If there is any intention to fix this and make the application available again, please open an issue on https://github.com/flathub/flathub/issues